### PR TITLE
Add Marina Wallet (browser extension)

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -43,5 +43,6 @@
 	"lnbits/lnbits",
 	"btcsuite/btcd",
 	"btcsuite/btcwallet",
-	"BlueWallet/rn-ldk"
+	"BlueWallet/rn-ldk",
+	"vulpemventures/marina"
 ]


### PR DESCRIPTION
browser extension to access Liquid Network and develop dapps on Liquid. (ie. metamask for Liquid)