### PR TITLE
repositories: add plebnet-playground-docker

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -43,5 +43,6 @@
 	"lnbits/lnbits",
 	"btcsuite/btcd",
 	"btcsuite/btcwallet",
-	"BlueWallet/rn-ldk"
+	"BlueWallet/rn-ldk",
+	"PLEBNET-PLAYGROUND/plebnet-playground-docker"
 ]


### PR DESCRIPTION
[PLEBNET-PLAYGROUND/plebnet-playground-docker](https://github.com/RandyMcMillan/plebnet-playground-docker) is a
dockerized bitcoin signet lightning stack.

About

A Docker package which allows users to use and test
bitcoin and lightning technologies without the
financial risk involved with running on the
mainnet chain. Multiple GUI interfaces are included.